### PR TITLE
Add sanity checks

### DIFF
--- a/contents/salt_node_executor.py
+++ b/contents/salt_node_executor.py
@@ -29,6 +29,19 @@ def main():
     data = parse_data(data_items)
     log.debug(f"Data: {sanitize_dict(data, ['password'])}")
 
+    # Sanity checks
+    if data['cmd'] is None or data['cmd'] == '':
+        log.warning('No command specified. There is nothing to do.')
+        sys.exit(0)
+
+    if data['host'] is None or data['host'] == '':
+        log.critical('There is no hostname defined for the Node. Command not send.')
+        sys.exit(1)
+
+    if data['url'] is None or data['url'] == '':
+        log.critical('No URL to Salt API specified.')
+        sys.exit(1)
+
     # prepare payload contents
     args = [data['cmd']]
 


### PR DESCRIPTION
To simplify troubleshooting, catch trivial issues early, such as missing hostname, api url, or empty command input in the NodeExecutor